### PR TITLE
Add Maths reference script for GAN curriculum

### DIFF
--- a/Maths.py
+++ b/Maths.py
@@ -1,0 +1,109 @@
+"""Resumen de los fundamentos matemáticos para el curso de GANs.
+
+Este módulo puede ejecutarse como script para mostrar de forma ordenada
+las expresiones y conceptos que el profesorado debe repasar con el grupo
+antes y durante las prácticas. El objetivo es ofrecer referencias
+compactas sin depender de frameworks externos, en concordancia con el
+resto del repositorio.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List
+
+
+@dataclass(frozen=True)
+class TemaMatematico:
+    """Agrupa fórmulas y recordatorios conceptuales."""
+
+    titulo: str
+    ideas_clave: List[str]
+    formulas: List[str]
+
+
+TEMARIO_MATEMATICO: List[TemaMatematico] = [
+    TemaMatematico(
+        titulo="Probabilidad y variables aleatorias",
+        ideas_clave=[
+            "Definir distribuciones objetivo (reales) y latentes (ruido).",
+            "Interpretar la generación como transformación de ruido: G(z).",
+            "Recordar propiedades de mezclas gaussianas y ley de los grandes números.",
+        ],
+        formulas=[
+            r"z \sim \mathcal{N}(0, I_d)",
+            r"p_{\text{datos}}(x) = \sum_k \pi_k \mathcal{N}(x; \mu_k, \Sigma_k)",
+        ],
+    ),
+    TemaMatematico(
+        titulo="Redes neuronales feedforward",
+        ideas_clave=[
+            "Revisar propagación hacia delante con pesos y sesgos densos.",
+            "Explicar el papel de las activaciones no lineales y su derivada.",
+            "Introducir la retropropagación como aplicación de la regla de la cadena.",
+        ],
+        formulas=[
+            r"z^{(l)} = a^{(l-1)} W^{(l)} + b^{(l)}",
+            r"a^{(l)} = g(z^{(l)})",
+            r"\frac{\partial \mathcal{L}}{\partial W^{(l)}} = (a^{(l-1)})^\top \delta^{(l)}",
+            r"\delta^{(l-1)} = \delta^{(l)} (W^{(l)})^\top \odot g'(z^{(l-1)})",
+        ],
+    ),
+    TemaMatematico(
+        titulo="Pérdidas y divergencias",
+        ideas_clave=[
+            "Contrastar MSE para autoencoders con BCE para clasificación.",
+            "Mostrar la conexión entre BCE y máxima verosimilitud.",
+            "Relacionar el objetivo adversarial con la divergencia de Jensen-Shannon.",
+        ],
+        formulas=[
+            r"\mathcal{L}_{\text{MSE}} = \frac{1}{N} \sum_{i=1}^N \|x_i - \hat{x}_i\|_2^2",
+            r"\mathcal{L}_{\text{BCE}} = -\frac{1}{N} \sum [y_i \log p_i + (1-y_i) \log(1-p_i)]",
+            r"\text{JSD}(P \| Q) = \frac{1}{2} \text{KL}(P \| M) + \frac{1}{2} \text{KL}(Q \| M)",
+        ],
+    ),
+    TemaMatematico(
+        titulo="Entrenamiento adversarial",
+        ideas_clave=[
+            "Descomponer el juego minimax entre generador (G) y discriminador (D).",
+            "Justificar las actualizaciones alternadas y el gradiente adversarial.",
+            "Analizar saturación del gradiente y trucos: label smoothing, clipping.",
+        ],
+        formulas=[
+            r"\min_G \max_D V(D, G) = \mathbb{E}_{x \sim p_{\text{datos}}}[\log D(x)] + \mathbb{E}_{z}[\log(1 - D(G(z)))]",
+            r"\nabla_{\theta_D} \mathcal{L}_D = -\nabla_{\theta_D} \mathbb{E}_{x}[\log D(x)] - \nabla_{\theta_D} \mathbb{E}_{z}[\log(1 - D(G(z)))]",
+            r"\nabla_{\theta_G} \mathcal{L}_G = -\nabla_{\theta_G} \mathbb{E}_{z}[\log D(G(z))]",
+        ],
+    ),
+    TemaMatematico(
+        titulo="Evaluación de modelos generativos",
+        ideas_clave=[
+            "Comparar distribuciones mediante histogramas, proyecciones y métricas simples.",
+            "Explicar la noción de sobreajuste en el generador vs colapso de modo.",
+            "Discutir métricas opcionales (distancia Wasserstein, FID) aunque no se implementen.",
+        ],
+        formulas=[
+            r"\text{EMD}(P, Q) = \inf_{\gamma \in \Pi(P, Q)} \mathbb{E}_{(x, y) \sim \gamma}[\|x - y\|]",
+            r"\text{FID}(X, Y) = \|\mu_X - \mu_Y\|_2^2 + \text{Tr}(\Sigma_X + \Sigma_Y - 2(\Sigma_X \Sigma_Y)^{1/2})",
+        ],
+    ),
+]
+
+
+def mostrar_matematicas() -> None:
+    """Imprime el temario matemático en formato amigable."""
+
+    for tema in TEMARIO_MATEMATICO:
+        print(tema.titulo)
+        print("  Ideas clave:")
+        for idea in tema.ideas_clave:
+            print(f"    - {idea}")
+        if tema.formulas:
+            print("  Fórmulas a destacar:")
+            for formula in tema.formulas:
+                print(f"    * {formula}")
+        print()
+
+
+if __name__ == "__main__":
+    mostrar_matematicas()

--- a/activaciones.py
+++ b/activaciones.py
@@ -1,26 +1,43 @@
 import numpy as np
 
+
 def lineal(z):
     return z
+
 
 def derivada_lineal(z):
     return np.ones(z.shape)
 
+
 def sigmoide(z):
     return 1 / (1 + np.exp(-z))
+
 
 def derivada_sigmoide(z):
     g = sigmoide(z)
     return g * (1 - g)
 
+
 def relu(z):
     return np.maximum(0, z)
 
+
 def derivada_relu(z):
     return (z > 0).astype(float)
+
+
+def tangente_hiperbolica(z):
+    return np.tanh(z)
+
+
+def derivada_tangente_hiperbolica(z):
+    g = np.tanh(z)
+    return 1 - g**2
+
 
 mapa_activaciones = {
     'lineal': (lineal, derivada_lineal),
     'sigmoide': (sigmoide, derivada_sigmoide),
     'relu': (relu, derivada_relu),
+    'tanh': (tangente_hiperbolica, derivada_tangente_hiperbolica),
 }

--- a/autoencoder.py
+++ b/autoencoder.py
@@ -1,5 +1,5 @@
 import numpy as np
-import src.activaciones as act
+import activaciones as act
 
 def codificador(X, parametros, activaciones):
     medio = len(activaciones) // 2

--- a/gan_discriminador.py
+++ b/gan_discriminador.py
@@ -1,0 +1,74 @@
+r"""Entrenamiento supervisado del discriminador antes del ciclo adversarial.
+
+Se utiliza la pérdida de entropía cruzada binaria
+
+.. math::
+   \mathcal{L}_D(\theta_D) = -\frac{1}{N} \sum_{i=1}^N 
+   \left[y_i \log D(x_i) + (1-y_i) \log (1 - D(x_i))\right]
+
+para separar ejemplos reales (:math:`y=1`) de ejemplos sintéticos (:math:`y=0`).
+"""
+
+from __future__ import annotations
+
+from typing import List, Tuple
+
+import numpy as np
+
+import costos
+from gan_modelos import ConfiguracionModelo, ModeloDenso, mezclar_batches
+
+
+def preparar_conjunto_discriminador(
+    reales: np.ndarray,
+    falsos: np.ndarray,
+) -> Tuple[np.ndarray, np.ndarray]:
+    """Concatena datos reales/falsos y asigna etiquetas binaras."""
+
+    y_reales = np.ones((reales.shape[0], 1), dtype=np.float64)
+    y_falsos = np.zeros((falsos.shape[0], 1), dtype=np.float64)
+
+    X = np.concatenate([reales, falsos], axis=0)
+    y = np.concatenate([y_reales, y_falsos], axis=0)
+    return X, y
+
+
+def entrenar_discriminador(
+    datos_reales: np.ndarray,
+    datos_falsos: np.ndarray,
+    config: ConfiguracionModelo,
+    epocas: int = 100,
+    tamano_lote: int = 128,
+    semilla: int | None = None,
+) -> Tuple[ModeloDenso, List[float]]:
+    """Ajusta un discriminador ``D`` previo al entrenamiento adversarial."""
+
+    if semilla is not None:
+        np.random.seed(semilla)
+
+    discriminador = ModeloDenso(config)
+    _, derivada_bce = costos.mapa_costos['bce']
+    historial: List[float] = []
+
+    X, y = preparar_conjunto_discriminador(datos_reales, datos_falsos)
+    n = X.shape[0]
+
+    for epoca in range(epocas):
+        X_bar, y_bar = mezclar_batches(X, y)
+
+        for inicio in range(0, n, tamano_lote):
+            fin = inicio + tamano_lote
+            batch_X = X_bar[inicio:fin]
+            batch_y = y_bar[inicio:fin]
+
+            pred, cache = discriminador.forward(batch_X)
+            derivadas = discriminador.retropropagar(
+                pred, batch_y, cache, derivada_bce
+            )
+            discriminador.actualizar(derivadas)
+
+        pred_epoca, _ = discriminador.forward(X)
+        perdidas = costos.bce(y, pred_epoca)
+        historial.append(float(perdidas))
+
+    return discriminador, historial

--- a/gan_ejemplo_1d.py
+++ b/gan_ejemplo_1d.py
@@ -1,0 +1,78 @@
+r"""Práctica: GAN unidimensional para aproximar una mezcla gaussiana.
+
+Distribución objetivo:
+
+.. math::
+   p_{\text{real}}(x) = 0.5\,\mathcal{N}(-2, 0.2^2) + 0.5\,\mathcal{N}(2, 0.2^2).
+
+El objetivo es que ``G`` aprenda a producir muestras 1D que sigan dicha mezcla
+utilizando capas densas pequeñas.
+"""
+
+from __future__ import annotations
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+from gan_entrenamiento_adversarial import (
+    entrenar_gan,
+    graficar_historial,
+    generar_muestras,
+)
+from gan_modelos import ConfiguracionModelo
+
+
+def datos_reales_1d(n_muestras: int, rng: np.random.Generator | None = None) -> np.ndarray:
+    """Muestra valores de la mezcla gaussiana propuesta."""
+
+    if rng is None:
+        rng = np.random.default_rng()
+    componentes = rng.integers(0, 2, size=n_muestras)
+    medias = np.where(componentes == 0, -2.0, 2.0)
+    muestras = rng.normal(loc=medias, scale=0.2)
+    return muestras.reshape(-1, 1)
+
+
+def ejecutar_practica(epocas: int = 400) -> None:
+    """Entrena una GAN simple y visualiza resultados."""
+
+    rng = np.random.default_rng(42)
+    datos = datos_reales_1d(2000, rng)
+
+    config_gen = ConfiguracionModelo(
+        dimensiones=[1, 16, 16, 1],
+        activaciones=['relu', 'relu', 'tanh'],
+        lr=1e-3,
+    )
+    config_disc = ConfiguracionModelo(
+        dimensiones=[1, 32, 32, 1],
+        activaciones=['relu', 'relu', 'sigmoide'],
+        lr=1e-3,
+    )
+
+    generador, discriminador, historial = entrenar_gan(
+        datos,
+        config_gen,
+        config_disc,
+        epocas=epocas,
+        tamano_lote=128,
+        dimension_ruido=1,
+        semilla=42,
+    )
+
+    graficar_historial(historial)
+
+    muestras = generar_muestras(generador, 1000, dimension_ruido=1, rng=rng)
+
+    plt.figure(figsize=(8, 4))
+    plt.hist(datos, bins=50, density=True, alpha=0.6, label='Reales')
+    plt.hist(muestras, bins=50, density=True, alpha=0.6, label='Sintéticas')
+    plt.title('Comparación distribución real vs generada')
+    plt.xlabel('x')
+    plt.ylabel('densidad')
+    plt.legend()
+    plt.show()
+
+
+if __name__ == '__main__':
+    ejecutar_practica()

--- a/gan_ejemplo_2d.py
+++ b/gan_ejemplo_2d.py
@@ -1,0 +1,70 @@
+r"""Práctica 2D con ``make_moons`` para visualizar el aprendizaje adversarial.
+
+La distribución objetivo corresponde a dos semicírculos desplazados. Puede
+interpretarse como el conjunto
+
+.. math::
+   \{(x, y) \in \mathbb{R}^2 : (x \pm 0.5)^2 + y^2 = 1 \}
+
+corrompido con ruido gaussiano.
+"""
+
+from __future__ import annotations
+
+import matplotlib.pyplot as plt
+import numpy as np
+from sklearn.datasets import make_moons
+
+from gan_entrenamiento_adversarial import entrenar_gan, graficar_historial
+from gan_entrenamiento_adversarial import generar_muestras as generar_sinteticos
+from gan_modelos import ConfiguracionModelo
+
+
+def datos_reales_2d(n_muestras: int = 2000, ruido: float = 0.1, semilla: int = 42) -> np.ndarray:
+    """Genera ``make_moons`` escalado a ``[-1, 1]``."""
+
+    datos, _ = make_moons(n_samples=n_muestras, noise=ruido, random_state=semilla)
+    datos = datos.astype(np.float64)
+    minimo = datos.min(axis=0, keepdims=True)
+    maximo = datos.max(axis=0, keepdims=True)
+    return 2 * (datos - minimo) / (maximo - minimo) - 1
+
+
+def ejecutar_practica(epocas: int = 400) -> None:
+    datos = datos_reales_2d()
+
+    config_gen = ConfiguracionModelo(
+        dimensiones=[2, 32, 32, 2],
+        activaciones=['relu', 'relu', 'tanh'],
+        lr=2e-3,
+    )
+    config_disc = ConfiguracionModelo(
+        dimensiones=[2, 64, 64, 1],
+        activaciones=['relu', 'relu', 'sigmoide'],
+        lr=2e-3,
+    )
+
+    generador, discriminador, historial = entrenar_gan(
+        datos,
+        config_gen,
+        config_disc,
+        epocas=epocas,
+        tamano_lote=128,
+        dimension_ruido=2,
+        semilla=123,
+    )
+
+    graficar_historial(historial)
+
+    muestras = generar_sinteticos(generador, 2000, dimension_ruido=2)
+
+    plt.figure(figsize=(6, 6))
+    plt.scatter(datos[:, 0], datos[:, 1], s=10, alpha=0.5, label='Reales')
+    plt.scatter(muestras[:, 0], muestras[:, 1], s=10, alpha=0.5, label='Sintéticas')
+    plt.title('GAN 2D - Make Moons')
+    plt.legend()
+    plt.show()
+
+
+if __name__ == '__main__':
+    ejecutar_practica()

--- a/gan_ejemplo_3d.py
+++ b/gan_ejemplo_3d.py
@@ -1,0 +1,76 @@
+r"""Práctica 3D: aproximar un ``swiss roll`` mediante GAN.
+
+El conjunto real se define por las ecuaciones paramétricas
+
+.. math::
+   x(t) = t \cos t,\quad y(t) = h,\quad z(t) = t \sin t
+
+con ``t`` uniforme y ``h`` ruido vertical. ``make_swiss_roll`` de ``sklearn`` se
+usa para sintetizar el dataset real.
+"""
+
+from __future__ import annotations
+
+import matplotlib.pyplot as plt
+import numpy as np
+from mpl_toolkits.mplot3d import Axes3D  # noqa: F401
+from sklearn.datasets import make_swiss_roll
+
+from gan_entrenamiento_adversarial import entrenar_gan, graficar_historial
+from gan_entrenamiento_adversarial import generar_muestras as generar_sinteticos
+from gan_modelos import ConfiguracionModelo
+
+
+def datos_reales_3d(n_muestras: int = 3000, ruido: float = 0.2, semilla: int = 0) -> np.ndarray:
+    """Swiss roll normalizado a ``[-1, 1]`` en cada eje."""
+
+    datos, _ = make_swiss_roll(n_samples=n_muestras, noise=ruido, random_state=semilla)
+    datos = datos.astype(np.float64)
+    minimo = datos.min(axis=0, keepdims=True)
+    maximo = datos.max(axis=0, keepdims=True)
+    return 2 * (datos - minimo) / (maximo - minimo) - 1
+
+
+def ejecutar_practica(epocas: int = 400) -> None:
+    datos = datos_reales_3d()
+
+    config_gen = ConfiguracionModelo(
+        dimensiones=[3, 64, 64, 3],
+        activaciones=['relu', 'relu', 'tanh'],
+        lr=1e-3,
+    )
+    config_disc = ConfiguracionModelo(
+        dimensiones=[3, 128, 128, 1],
+        activaciones=['relu', 'relu', 'sigmoide'],
+        lr=1e-3,
+    )
+
+    generador, discriminador, historial = entrenar_gan(
+        datos,
+        config_gen,
+        config_disc,
+        epocas=epocas,
+        tamano_lote=256,
+        dimension_ruido=3,
+        semilla=7,
+    )
+
+    graficar_historial(historial)
+
+    muestras = generar_sinteticos(generador, 3000, dimension_ruido=3)
+
+    fig = plt.figure(figsize=(12, 5))
+    ax1 = fig.add_subplot(121, projection='3d')
+    ax2 = fig.add_subplot(122, projection='3d')
+
+    ax1.scatter(datos[:, 0], datos[:, 1], datos[:, 2], s=4, alpha=0.5)
+    ax1.set_title('Datos reales')
+
+    ax2.scatter(muestras[:, 0], muestras[:, 1], muestras[:, 2], s=4, alpha=0.5)
+    ax2.set_title('Datos sintéticos')
+
+    plt.show()
+
+
+if __name__ == '__main__':
+    ejecutar_practica()

--- a/gan_ejemplo_imagenes.py
+++ b/gan_ejemplo_imagenes.py
@@ -1,0 +1,85 @@
+r"""Práctica final: generación de dígitos (8x8) con una GAN totalmente densa.
+
+Los píxeles se normalizan usando
+
+.. math::
+   \tilde{x} = 2\, (x - x_{\min}) / (x_{\max} - x_{\min}) - 1
+
+para que el generador con activación ``tanh`` produzca valores acordes.
+"""
+
+from __future__ import annotations
+
+import matplotlib.pyplot as plt
+import numpy as np
+from sklearn.datasets import load_digits
+
+from gan_entrenamiento_adversarial import (
+    entrenar_gan,
+    graficar_historial,
+    generar_muestras,
+)
+from gan_modelos import ConfiguracionModelo
+
+
+def cargar_digitos() -> np.ndarray:
+    """Carga ``sklearn`` digits y los normaliza a ``[-1, 1]``."""
+
+    dataset = load_digits()
+    datos = dataset.data.astype(np.float64)
+    minimo = datos.min()
+    maximo = datos.max()
+    datos = 2 * (datos - minimo) / (maximo - minimo) - 1
+    return datos
+
+
+def mostrar_imagenes(arreglo: np.ndarray, n: int = 16, titulo: str = '') -> None:
+    """Muestra ``n`` imágenes 8x8 en una cuadrícula."""
+
+    lado = int(np.sqrt(n))
+    figuras = arreglo[: n].reshape(-1, 8, 8)
+
+    fig, axes = plt.subplots(lado, lado, figsize=(6, 6))
+    for ax, imagen in zip(axes.flatten(), figuras):
+        ax.imshow(imagen, cmap='gray', vmin=-1, vmax=1)
+        ax.axis('off')
+    if titulo:
+        fig.suptitle(titulo)
+    plt.show()
+
+
+def ejecutar_practica(epocas: int = 400) -> None:
+    datos = cargar_digitos()
+
+    config_gen = ConfiguracionModelo(
+        dimensiones=[16, 128, 128, 64],
+        activaciones=['relu', 'relu', 'tanh'],
+        lr=2e-3,
+    )
+    config_disc = ConfiguracionModelo(
+        dimensiones=[64, 128, 64, 1],
+        activaciones=['relu', 'relu', 'sigmoide'],
+        lr=2e-3,
+    )
+
+    generador, discriminador, historial = entrenar_gan(
+        datos,
+        config_gen,
+        config_disc,
+        epocas=epocas,
+        tamano_lote=128,
+        dimension_ruido=16,
+        semilla=21,
+    )
+
+    graficar_historial(historial)
+
+    reales = datos[:16]
+    sinteticos = generar_muestras(generador, 16, dimension_ruido=16)
+
+    mostrar_imagenes(reales, titulo='Ejemplos reales')
+    mostrar_imagenes(sinteticos, titulo='Ejemplos generados')
+
+
+if __name__ == '__main__':
+    ejecutar_practica()

--- a/gan_entrenamiento_adversarial.py
+++ b/gan_entrenamiento_adversarial.py
@@ -1,0 +1,207 @@
+"""Rutinas de entrenamiento adversarial para unir ``G`` y ``D``.
+
+El lazo básico sigue el esquema:
+
+1. Actualizar :math:`\theta_D` maximizando ``log D(x) + log(1 - D(G(z)))``.
+2. Actualizar :math:`\theta_G` minimizando ``-log D(G(z))``.
+
+Cada paso se implementa como funciones independientes para facilitar la
+experimentación en clase.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Tuple
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+import costos
+from gan_modelos import (
+    ConfiguracionModelo,
+    ModeloDenso,
+    evaluar_bce,
+    gradiente_bce,
+    mezclar_batches,
+    muestrear_ruido,
+)
+
+
+@dataclass
+class HistorialAdversarial:
+    """Almacena pérdidas y métricas de una sesión de entrenamiento."""
+
+    costo_generador: List[float]
+    costo_discriminador: List[float]
+    prob_real: List[float]
+    prob_fake: List[float]
+
+
+def paso_discriminador(
+    discriminador: ModeloDenso,
+    generador: ModeloDenso,
+    reales: np.ndarray,
+    dimension_ruido: int,
+    rng: np.random.Generator,
+) -> Tuple[float, float, float]:
+    """Ejecuta un paso de gradiente sobre ``D``."""
+
+    _, derivada_bce = costos.mapa_costos['bce']
+
+    ruido = muestrear_ruido(reales.shape[0], dimension_ruido, rng=rng)
+    falsos, _ = generador.forward(ruido)
+
+    entradas = np.concatenate([reales, falsos], axis=0)
+    etiquetas = np.concatenate(
+        [np.ones((reales.shape[0], 1)), np.zeros((falsos.shape[0], 1))], axis=0
+    )
+
+    entradas, etiquetas = mezclar_batches(entradas, etiquetas)
+
+    pred, cache = discriminador.forward(entradas)
+    derivadas = discriminador.retropropagar(pred, etiquetas, cache, derivada_bce)
+    discriminador.actualizar(derivadas)
+
+    perdida = evaluar_bce(etiquetas, pred)
+    prob_real = float(discriminador.forward(reales)[0].mean())
+    prob_fake = float(discriminador.forward(falsos)[0].mean())
+    return perdida, prob_real, prob_fake
+
+
+def paso_generador(
+    discriminador: ModeloDenso,
+    generador: ModeloDenso,
+    tamano_lote: int,
+    dimension_ruido: int,
+    rng: np.random.Generator,
+) -> Tuple[float, float]:
+    """Actualiza ``G`` buscando ``D(G(z)) -> 1``."""
+
+    _, derivada_bce = costos.mapa_costos['bce']
+
+    ruido = muestrear_ruido(tamano_lote, dimension_ruido, rng=rng)
+    falsos, cache_g = generador.forward(ruido)
+
+    etiquetas_objetivo = np.ones((tamano_lote, 1))
+    pred_fake, cache_d = discriminador.forward(falsos)
+
+    gradiente_salida = gradiente_bce(etiquetas_objetivo, pred_fake)
+    _, gradiente_entrada = discriminador.retropropagar(
+        pred_fake,
+        etiquetas_objetivo,
+        cache_d,
+        derivada_bce,
+        gradiente_salida=gradiente_salida,
+        retornar_gradiente_entrada=True,
+    )
+
+    derivadas_g = generador.retropropagar(
+        falsos,
+        np.zeros_like(falsos),
+        cache_g,
+        gradiente_salida=gradiente_entrada,
+    )
+    generador.actualizar(derivadas_g)
+
+    perdida = evaluar_bce(etiquetas_objetivo, pred_fake)
+    return perdida, float(pred_fake.mean())
+
+
+def entrenar_gan(
+    datos_reales: np.ndarray,
+    config_generador: ConfiguracionModelo,
+    config_discriminador: ConfiguracionModelo,
+    epocas: int = 200,
+    tamano_lote: int = 128,
+    dimension_ruido: int = 2,
+    semilla: int | None = None,
+) -> Tuple[ModeloDenso, ModeloDenso, HistorialAdversarial]:
+    """Entrenamiento adversarial clásico con NumPy puro."""
+
+    if semilla is not None:
+        np.random.seed(semilla)
+    rng = np.random.default_rng(semilla)
+
+    generador = ModeloDenso(config_generador)
+    discriminador = ModeloDenso(config_discriminador)
+
+    historial = HistorialAdversarial([], [], [], [])
+    n = datos_reales.shape[0]
+
+    for epoca in range(epocas):
+        indices = np.random.permutation(n)
+        datos_reales = datos_reales[indices]
+
+        perdidas_g: List[float] = []
+        perdidas_d: List[float] = []
+        prob_reales: List[float] = []
+        prob_falsos: List[float] = []
+
+        for inicio in range(0, n, tamano_lote):
+            fin = inicio + tamano_lote
+            reales_batch = datos_reales[inicio:fin]
+
+            if reales_batch.shape[0] == 0:
+                continue
+
+            perdida_d, prob_real, _ = paso_discriminador(
+                discriminador, generador, reales_batch, dimension_ruido, rng
+            )
+            perdidas_d.append(perdida_d)
+            prob_reales.append(prob_real)
+
+            perdida_g, prob_fake = paso_generador(
+                discriminador,
+                generador,
+                reales_batch.shape[0],
+                dimension_ruido,
+                rng,
+            )
+            perdidas_g.append(perdida_g)
+            prob_falsos.append(prob_fake)
+
+        historial.costo_generador.append(float(np.mean(perdidas_g)))
+        historial.costo_discriminador.append(float(np.mean(perdidas_d)))
+        historial.prob_real.append(float(np.mean(prob_reales)))
+        historial.prob_fake.append(float(np.mean(prob_falsos)))
+
+    return generador, discriminador, historial
+
+
+def graficar_historial(historial: HistorialAdversarial) -> None:
+    """Genera figuras para analizar el entrenamiento."""
+
+    fig, axes = plt.subplots(1, 2, figsize=(10, 4))
+
+    axes[0].plot(historial.costo_generador, label='Generador')
+    axes[0].plot(historial.costo_discriminador, label='Discriminador')
+    axes[0].set_title('Pérdidas adversariales')
+    axes[0].set_xlabel('Época')
+    axes[0].set_ylabel('BCE')
+    axes[0].legend()
+
+    axes[1].plot(historial.prob_real, label='D(x_real)')
+    axes[1].plot(historial.prob_fake, label='D(G(z))')
+    axes[1].set_title('Confianza del discriminador')
+    axes[1].set_xlabel('Época')
+    axes[1].set_ylabel('Probabilidad')
+    axes[1].legend()
+
+    fig.tight_layout()
+    plt.show()
+
+
+def generar_muestras(
+    generador: ModeloDenso,
+    n_muestras: int,
+    dimension_ruido: int,
+    rng: np.random.Generator | None = None,
+) -> np.ndarray:
+    """Conveniencia para sintetizar datos con ``G``."""
+
+    if rng is None:
+        rng = np.random.default_rng()
+    ruido = muestrear_ruido(n_muestras, dimension_ruido, rng=rng)
+    muestras, _ = generador.forward(ruido)
+    return muestras

--- a/gan_generador_autoencoder.py
+++ b/gan_generador_autoencoder.py
@@ -1,0 +1,127 @@
+r"""Pre-entrenamiento del generador a partir de un autoencoder denso.
+
+La idea pedagógica es reutilizar el decodificador de un autoencoder ya
+entrenado como punto de partida del generador :math:`G`. Al minimizar la
+pérdida de reconstrucción
+
+.. math::
+   \mathcal{L}_{\text{rec}} = \frac{1}{N} \sum_{i=1}^N \lVert x_i - \hat x_i \rVert_2^2,
+
+aprendemos un mapeo suave de un espacio latente a la distribución de datos, lo
+cual proporciona pesos iniciales informados para el generador de la GAN.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, List, Tuple
+
+import numpy as np
+
+import costos
+from gan_modelos import ConfiguracionModelo, ModeloDenso, mezclar_batches
+
+
+def entrenar_autoencoder(
+    datos: np.ndarray,
+    config: ConfiguracionModelo,
+    epocas: int = 200,
+    tamano_lote: int = 128,
+    semilla: int | None = None,
+) -> Tuple[ModeloDenso, List[float]]:
+    r"""Ajusta un autoencoder simétrico sobre ``datos``.
+
+    Parameters
+    ----------
+    datos:
+        Matriz ``(N, d)`` que servirá simultáneamente como entrada y objetivo.
+    config:
+        Configuración de la red (debe ser simétrica para separar encoder y
+        decoder).
+    epocas, tamano_lote, semilla:
+        Hiperparámetros del descenso de gradiente mini-batch.
+
+    Returns
+    -------
+    autoencoder, historial
+        Modelo entrenado y lista con ``\mathcal{L}_{\text{rec}}`` por época.
+    """
+
+    if semilla is not None:
+        np.random.seed(semilla)
+
+    autoencoder = ModeloDenso(config)
+    costo_mse, derivada_mse = costos.mapa_costos['mse']
+
+    historial: List[float] = []
+    n = datos.shape[0]
+
+    for epoca in range(epocas):
+        (datos_barajados,) = mezclar_batches(datos)
+
+        for inicio in range(0, n, tamano_lote):
+            fin = inicio + tamano_lote
+            batch = datos_barajados[inicio:fin]
+
+            salida, cache = autoencoder.forward(batch)
+            derivadas = autoencoder.retropropagar(
+                salida, batch, cache, derivada_mse
+            )
+            autoencoder.actualizar(derivadas)
+
+        reconstruccion, _ = autoencoder.forward(datos)
+        perdida = float(costo_mse(datos, reconstruccion))
+        historial.append(perdida)
+
+    return autoencoder, historial
+
+
+def extraer_generador_desde_autoencoder(
+    autoencoder: ModeloDenso,
+) -> Tuple[ModeloDenso, Dict[str, np.ndarray]]:
+    """Copia el decodificador del autoencoder como generador ``G``.
+
+    Returns
+    -------
+    generador, parametros
+        Instancia lista para usarse junto con sus pesos.
+    """
+
+    config_auto = autoencoder.config
+    mitad = len(config_auto.activaciones) // 2
+
+    dimensiones_generador = config_auto.dimensiones[mitad:]
+    activaciones_generador = config_auto.activaciones[mitad:]
+
+    config_gen = ConfiguracionModelo(
+        dimensiones=dimensiones_generador,
+        activaciones=activaciones_generador,
+        lr=config_auto.lr,
+        optimizador=config_auto.optimizador,
+    )
+    generador = ModeloDenso(config_gen)
+
+    for i in range(1, len(dimensiones_generador)):
+        generador.parametros[f'W{i}'] = autoencoder.parametros[f'W{mitad + i}'].copy()
+        generador.parametros[f'b{i}'] = autoencoder.parametros[f'b{mitad + i}'].copy()
+
+    return generador, generador.parametros
+
+
+def inicializar_generador_con_autoencoder(
+    datos: np.ndarray,
+    config_autoencoder: ConfiguracionModelo,
+    epocas: int = 200,
+    tamano_lote: int = 128,
+    semilla: int | None = None,
+) -> Tuple[ModeloDenso, List[float]]:
+    """Conveniencia: entrena el autoencoder y devuelve sólo el generador.
+
+    La salida es el par ``(generador, historial_rec)`` con el que se puede
+    iniciar el bloque de entrenamiento adversarial.
+    """
+
+    autoencoder, historial = entrenar_autoencoder(
+        datos, config_autoencoder, epocas=epocas, tamano_lote=tamano_lote, semilla=semilla
+    )
+    generador, _ = extraer_generador_desde_autoencoder(autoencoder)
+    return generador, historial

--- a/gan_inicio_proyecto.py
+++ b/gan_inicio_proyecto.py
@@ -1,0 +1,110 @@
+r"""Guion paso a paso: generador → discriminador → entrenamiento adversarial.
+
+Este script enlaza los módulos especializados en tres etapas:
+
+1. **Generador**: se obtiene a partir de un autoencoder, minimizando
+   :math:`\mathcal{L}_{\text{rec}}`.
+2. **Discriminador**: se entrena con ``BCE`` sobre datos reales y sintéticos
+   fijos.
+3. **Unión adversarial**: se optimizan simultáneamente ``G`` y ``D`` usando las
+   pérdidas descritas en ``gan_entrenamiento_adversarial``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List
+
+import numpy as np
+
+from gan_discriminador import entrenar_discriminador
+from gan_entrenamiento_adversarial import HistorialAdversarial, entrenar_gan
+from gan_generador_autoencoder import inicializar_generador_con_autoencoder
+from gan_modelos import ConfiguracionModelo, ModeloDenso, muestrear_ruido
+
+
+@dataclass
+class PasoGenerador:
+    generador: ModeloDenso
+    historial_reconstruccion: List[float]
+
+
+@dataclass
+class PasoDiscriminador:
+    discriminador: ModeloDenso
+    historial_discriminador: List[float]
+
+
+@dataclass
+class PasoAdversarial:
+    generador: ModeloDenso
+    discriminador: ModeloDenso
+    historial: HistorialAdversarial
+
+
+def etapa_generador(
+    datos: np.ndarray,
+    config_autoencoder: ConfiguracionModelo,
+    epocas: int = 200,
+    tamano_lote: int = 128,
+    semilla: int | None = None,
+) -> PasoGenerador:
+    """Entrena un autoencoder y devuelve el generador inicial."""
+
+    generador, historial = inicializar_generador_con_autoencoder(
+        datos,
+        config_autoencoder,
+        epocas=epocas,
+        tamano_lote=tamano_lote,
+        semilla=semilla,
+    )
+    return PasoGenerador(generador, historial)
+
+
+def etapa_discriminador(
+    datos_reales: np.ndarray,
+    generador: ModeloDenso,
+    config_discriminador: ConfiguracionModelo,
+    epocas: int = 100,
+    tamano_lote: int = 128,
+    dimension_ruido: int = 2,
+    semilla: int | None = None,
+) -> PasoDiscriminador:
+    """Congela ``G`` y entrena ``D`` con muestras fijas."""
+
+    rng = np.random.default_rng(semilla)
+    ruido = muestrear_ruido(datos_reales.shape[0], dimension_ruido, rng=rng)
+    datos_sinteticos, _ = generador.forward(ruido)
+
+    discriminador, historial = entrenar_discriminador(
+        datos_reales,
+        datos_sinteticos,
+        config_discriminador,
+        epocas=epocas,
+        tamano_lote=tamano_lote,
+        semilla=semilla,
+    )
+    return PasoDiscriminador(discriminador, historial)
+
+
+def etapa_adversarial(
+    datos_reales: np.ndarray,
+    config_generador: ConfiguracionModelo,
+    config_discriminador: ConfiguracionModelo,
+    epocas: int = 200,
+    tamano_lote: int = 128,
+    dimension_ruido: int = 2,
+    semilla: int | None = None,
+) -> PasoAdversarial:
+    """Realiza el ciclo de entrenamiento adversarial completo."""
+
+    generador, discriminador, historial = entrenar_gan(
+        datos_reales,
+        config_generador,
+        config_discriminador,
+        epocas=epocas,
+        tamano_lote=tamano_lote,
+        dimension_ruido=dimension_ruido,
+        semilla=semilla,
+    )
+    return PasoAdversarial(generador, discriminador, historial)

--- a/gan_leccion.py
+++ b/gan_leccion.py
@@ -1,0 +1,147 @@
+"""Mapa curricular de 28 horas para el curso de GAN con NumPy puro.
+
+El contenido ahora está dividido en scripts especializados para que el profesorado
+pueda ir activándolos sesión tras sesión dentro de PyCharm.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List
+
+
+@dataclass
+class Bloque:
+    titulo: str
+    horas: int
+    scripts: List[str]
+    temas: List[str]
+    matematicas: List[str] = field(default_factory=list)
+
+
+ITINERARIO_28_HORAS: List[Bloque] = [
+    Bloque(
+        titulo='Bloque 1 (Horas 1-4): Fundamentos de redes densas',
+        horas=4,
+        scripts=['gan_modelos.py'],
+        temas=[
+            'Repaso de perceptrón multicapa y activaciones (relu, sigmoide, tanh).',
+            'Inicialización de pesos y propagación hacia delante/atrás.',
+            'Definición de pérdidas MSE y BCE con sus gradientes analíticos.',
+        ],
+        matematicas=[
+            r'a^{(l)} = g(z^{(l)}),\; z^{(l)} = a^{(l-1)}W^{(l)} + b^{(l)}',
+            r'\mathcal{L}_{\text{BCE}} = -\frac{1}{N} \sum y \log p + (1-y) \log(1-p)',
+        ],
+    ),
+    Bloque(
+        titulo='Bloque 2 (Horas 5-10): Generador desde autoencoder',
+        horas=6,
+        scripts=['gan_generador_autoencoder.py', 'gan_inicio_proyecto.py'],
+        temas=[
+            'Entrenamiento no supervisado de autoencoders simétricos.',
+            'Transferencia del decodificador como generador inicial.',
+            'Exploración del historial de reconstrucción y ajuste de hiperparámetros.',
+        ],
+        matematicas=[
+            r'\mathcal{L}_{\text{rec}} = \lVert x - \hat x \rVert_2^2',
+            r'z \sim \mathcal{N}(0, I_d)',
+        ],
+    ),
+    Bloque(
+        titulo='Bloque 3 (Horas 11-16): Discriminador supervisado',
+        horas=6,
+        scripts=['gan_discriminador.py'],
+        temas=[
+            'Construcción del dataset etiquetado real/falso.',
+            'Descenso de gradiente mini-batch para maximizar la verosimilitud.',
+            'Métricas de desempeño: precisión y pérdida BCE.',
+        ],
+        matematicas=[
+            r'\nabla_{\theta_D} \mathcal{L}_D = \frac{1}{N} \sum (D(x)-y) \nabla_{\theta_D} f(x)',
+        ],
+    ),
+    Bloque(
+        titulo='Bloque 4 (Horas 17-20): Entrenamiento adversarial',
+        horas=4,
+        scripts=['gan_entrenamiento_adversarial.py', 'gan_inicio_proyecto.py'],
+        temas=[
+            'Implementación del lazo alternado G ↔ D.',
+            'Interpretación de las curvas de pérdida y saturación.',
+            'Discusión sobre estabilidad y trucos (label smoothing, clipping).',
+        ],
+        matematicas=[
+            r'\mathcal{L}_D = -\mathbb{E}_{x \sim p_{\text{real}}}[\log D(x)] - \mathbb{E}_{z}[\log(1-D(G(z)))]',
+            r'\mathcal{L}_G = -\mathbb{E}_{z}[\log D(G(z))]',
+        ],
+    ),
+    Bloque(
+        titulo='Bloque 5 (Horas 21-22): Caso 1D',
+        horas=2,
+        scripts=['gan_ejemplo_1d.py'],
+        temas=[
+            'Definición de mezclas gaussianas y muestreo de ruido 1D.',
+            'Comparación de histogramas y evaluación visual.',
+        ],
+        matematicas=[
+            r'p(x) = \sum_k \pi_k \mathcal{N}(\mu_k, \sigma_k^2)',
+        ],
+    ),
+    Bloque(
+        titulo='Bloque 6 (Horas 23-24): Caso 2D',
+        horas=2,
+        scripts=['gan_ejemplo_2d.py'],
+        temas=[
+            'Dataset ``make_moons`` como ejemplo de soporte no lineal.',
+            'Visualización de nubes de puntos reales vs generadas.',
+        ],
+        matematicas=[
+            r'(x \pm 0.5)^2 + y^2 = 1',
+        ],
+    ),
+    Bloque(
+        titulo='Bloque 7 (Horas 25-26): Caso 3D',
+        horas=2,
+        scripts=['gan_ejemplo_3d.py'],
+        temas=[
+            'Parametrización del ``swiss roll`` y normalización por ejes.',
+            'Uso de proyecciones 3D para evaluar calidad de las muestras.',
+        ],
+        matematicas=[
+            r'(x, y, z) = (t \cos t, h, t \sin t)',
+        ],
+    ),
+    Bloque(
+        titulo='Bloque 8 (Horas 27-28): Caso imágenes 8x8',
+        horas=2,
+        scripts=['gan_ejemplo_imagenes.py'],
+        temas=[
+            'Preparación de datos de dígitos y normalización a [-1, 1].',
+            'Análisis cualitativo de muestras generadas en cuadrículas.',
+        ],
+        matematicas=[
+            r'\tilde{x} = 2 (x - x_{\min})/(x_{\max}-x_{\min}) - 1',
+        ],
+    ),
+]
+
+
+def mostrar_plan() -> None:
+    """Imprime el plan de trabajo en formato legible."""
+
+    for bloque in ITINERARIO_28_HORAS:
+        print(bloque.titulo)
+        print(f'  Horas estimadas: {bloque.horas}')
+        print(f'  Scripts: {", ".join(bloque.scripts)}')
+        print('  Temas:')
+        for tema in bloque.temas:
+            print(f'    - {tema}')
+        if bloque.matematicas:
+            print('  Matemáticas clave:')
+            for formula in bloque.matematicas:
+                print(f'    * {formula}')
+        print()
+
+
+if __name__ == '__main__':
+    mostrar_plan()

--- a/gan_modelos.py
+++ b/gan_modelos.py
@@ -1,0 +1,180 @@
+r"""Utilidades fundamentales para construir generadores y discriminadores densos.
+
+El objetivo de este módulo es concentrar las piezas matemáticas mínimas
+necesarias para reutilizarlas en las distintas prácticas de la ruta de 28 horas
+sobre GAN. En particular se documentan las funciones de costo y los gradientes
+que se emplearán de forma repetida:
+
+* **Pérdida de reconstrucción** (autoencoder):
+  :math:`\mathcal{L}_{\text{rec}}(x, \hat x) = \lVert x - \hat x \rVert_2^2`.
+* **Pérdida adversarial del discriminador**:
+  :math:`\mathcal{L}_D = -\mathbb{E}_{x\sim p_{\text{real}}}\log D(x)
+  - \mathbb{E}_{z\sim p_z}\log (1 - D(G(z)))`.
+* **Pérdida adversarial del generador** (versión no saturada):
+  :math:`\mathcal{L}_G = -\mathbb{E}_{z\sim p_z} \log D(G(z))`.
+
+Cada función y clase expone los tensores que intervienen en las fórmulas para
+facilitar la discusión durante la clase.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Tuple
+
+import numpy as np
+
+import costos
+import optimizadores
+import red_neuronal
+
+
+@dataclass
+class ConfiguracionModelo:
+    r"""Define la arquitectura de una red densa y sus hiperparámetros.
+
+    Parameters
+    ----------
+    dimensiones:
+        Lista con el número de neuronas por capa (incluye entrada y salida).
+    activaciones:
+        Nombre de la activación por capa oculta/salida. Debe haber
+        ``len(dimensiones) - 1`` activaciones.
+    lr:
+        Tasa de aprendizaje :math:`\eta` para el optimizador seleccionado.
+    optimizador:
+        Clave del optimizador presente en ``optimizadores.mapa_optimizadores``.
+    """
+
+    dimensiones: List[int]
+    activaciones: List[str]
+    lr: float
+    optimizador: str = 'gd'
+
+    def __post_init__(self) -> None:
+        if len(self.dimensiones) - 1 != len(self.activaciones):
+            raise ValueError(
+                'El número de activaciones debe coincidir con el de capas '
+                'densas (salvo la de entrada).'
+            )
+
+
+class ModeloDenso:
+    r"""`Wrapper` ligero sobre ``red_neuronal`` para redes densas.
+
+    La propagación hacia delante calcula :math:`a^{(l)} = g(z^{(l)})` con
+    :math:`z^{(l)} = a^{(l-1)} W^{(l)} + b^{(l)}`. El método ``retropropagar``
+    devuelve gradientes compatibles con el algoritmo de retropropagación
+    tradicional.
+    """
+
+    def __init__(self, config: ConfiguracionModelo):
+        self.config = config
+        self.parametros = red_neuronal.inicializar_RNA(config.dimensiones)
+        self._optimizador = optimizadores.mapa_optimizadores[config.optimizador]
+
+    def forward(self, X: np.ndarray) -> Tuple[np.ndarray, Dict[str, np.ndarray]]:
+        """Propagación hacia delante.
+
+        Parameters
+        ----------
+        X:
+            Matriz ``(n_muestras, n_features)`` con las activaciones de entrada.
+
+        Returns
+        -------
+        tuple
+            Par ``(A_L, cache)`` con la salida y los valores intermedios que
+            requiere la retropropagación.
+        """
+
+        return red_neuronal.propagacion_adelante(
+            X, self.parametros, self.config.activaciones
+        )
+
+    def retropropagar(
+        self,
+        salida: np.ndarray,
+        objetivo: np.ndarray,
+        cache: Dict[str, np.ndarray],
+        derivada_costo=None,
+        gradiente_salida: np.ndarray | None = None,
+        retornar_gradiente_entrada: bool = False,
+    ):
+        r"""Ejecuta retropropagación sobre la red.
+
+        Parameters
+        ----------
+        salida:
+            Vector ``P`` de predicciones de la capa de salida.
+        objetivo:
+            Vector ``T`` con las etiquetas/targets.
+        cache:
+            Valores intermedios ``a`` y ``da/dz`` guardados en ``forward``.
+        derivada_costo:
+            Función :math:`\partial \mathcal{L} / \partial P`.
+        gradiente_salida:
+            Gradiente externo ya evaluado respecto a ``P``.
+        retornar_gradiente_entrada:
+            Si es ``True`` también se devuelve :math:`\partial \mathcal{L} /
+            \partial X`.
+        """
+
+        return red_neuronal.retropropagacion(
+            salida,
+            objetivo,
+            self.parametros,
+            cache,
+            derivada_costo=derivada_costo,
+            gradiente_salida=gradiente_salida,
+            retornar_gradiente_entrada=retornar_gradiente_entrada,
+        )
+
+    def actualizar(self, derivadas: Dict[str, np.ndarray]) -> None:
+        r"""Aplica una actualización de parámetros.
+
+        Se ejecuta ``\theta \leftarrow \theta - \eta \, \nabla_\theta`` a
+        través del optimizador seleccionado en la configuración.
+        """
+
+        self.parametros = self._optimizador(
+            self.parametros, derivadas, self.config.lr
+        )
+
+
+def muestrear_ruido(
+    n_muestras: int,
+    dimension: int,
+    escala: float = 1.0,
+    rng: np.random.Generator | None = None,
+) -> np.ndarray:
+    r"""Genera vectores de ruido gaussiano :math:`z \sim \mathcal{N}(0, \sigma^2 I)`."""
+
+    if rng is None:
+        rng = np.random.default_rng()
+    return rng.normal(loc=0.0, scale=escala, size=(n_muestras, dimension))
+
+
+def mezclar_batches(*arreglos: Iterable[np.ndarray]) -> Tuple[np.ndarray, ...]:
+    """Baraja de forma consistente varios arreglos de igual longitud."""
+
+    if not arreglos:
+        raise ValueError('Se requiere al menos un arreglo para mezclar.')
+
+    n = arreglos[0].shape[0]
+    indices = np.random.permutation(n)
+    return tuple(arreglo[indices] for arreglo in arreglos)
+
+
+def evaluar_bce(etiquetas: np.ndarray, probabilidades: np.ndarray) -> float:
+    """Calcula la entropía cruzada binaria media."""
+
+    costo_bce, _ = costos.mapa_costos['bce']
+    return float(costo_bce(etiquetas, probabilidades))
+
+
+def gradiente_bce(etiquetas: np.ndarray, probabilidades: np.ndarray) -> np.ndarray:
+    """Gradiente de la entropía cruzada binaria."""
+
+    _, derivada_bce = costos.mapa_costos['bce']
+    return derivada_bce(etiquetas, probabilidades)


### PR DESCRIPTION
## Summary
- add `Maths.py` to centralize the math concepts and formulas required for the GAN lessons
- provide a printable temario covering probability, feedforward networks, loss functions, adversarial objectives and evaluation metrics

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68cf0546ce008325aba51dc174151306